### PR TITLE
Fix width issues (side-scroll) and remove unused layout bits

### DIFF
--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -1,10 +1,6 @@
 ﻿@inject Microsoft.AspNetCore.Hosting.IHostingEnvironment HostingEnvironment
 @inject ISiteContextResolver siteResolver
 @{
-    bool sideNavVisible = true.Equals(ViewData["SideNavVisible"]);
-    string sideNavToggleClass = ViewData["SideNavToggle"]?.ToString() ?? "collapse";
-    bool asidePrimaryVisible = true.Equals(ViewData["AsidePrimaryVisible"]);
-    bool asideSecondaryVisible = true.Equals(ViewData["AsideSecondaryVisible"]);
     var Tenant = await siteResolver.ResolveSite(Context.Request.Host.Host, Context.Request.Path);
 }
 <!DOCTYPE html>
@@ -83,7 +79,7 @@
 					</a>
 				</div>
 				<div class="site-social_icon site-social_icon--twitter">
-					<a href="https://twitter.com/dotnetfdn" title="Follow on Twitter @dotnetfdn">
+					<a href="https://twitter.com/dotnetfdn" title="Follow on Twitter @@dotnetfdn">
 						<i class="fab fa-twitter"></i>
 					</a>
 				</div>
@@ -96,42 +92,12 @@
 		</div>
 	</header>
 
-	@*<main id="site_wrapper">
-		<div id="site_container" class="">
-			@RenderBody()
-		</div>
-	</main>*@
 	<div id="site_wrapper" class="container-fluid cs-container flex-fill">
-
-		<div class="row">
-			<main id="site_container" role="main" class="col order-3">
-				@await Html.PartialAsync("AlertsPartial")
-				@RenderBody()
-			</main>
-			@if (sideNavVisible)
-			{
-			<nav id="sidenavmenu" class=" col col-3 order-1 @sideNavToggleClass">
-				@RenderSection("SideNav", required: false)
-			</nav>
-
-			}
-			@if (asideSecondaryVisible)
-			{
-			<aside id="asideSecondary" class="col col-1 order-2">
-				@RenderSection("AsideSecondary", required: false)
-			</aside>
-
-			}
-			@if (asidePrimaryVisible)
-			{
-			<aside id="asidePrimary" class="col-12 col-md-2 col-sm-12  col-sm-12 order-4">
-				@RenderSection("AsidePrimary", required: false)
-			</aside>
-
-			}
-		</div>
+		<main id="site_container" role="main" class="w-100 order-3">
+			@await Html.PartialAsync("AlertsPartial")
+			@RenderBody()
+		</main>
 	</div>
-
 
 	<footer id="site-footer" class="sticky-bottom h-card">
 		<data class="u-url" href="/"></data>
@@ -153,7 +119,7 @@
 					</a>
 				</div>
 				<div class="site-social_icon site-social_icon--twitter">
-					<a href="https://twitter.com/dotnetfdn" title="Follow on Twitter @dotnetfdn">
+					<a href="https://twitter.com/dotnetfdn" title="Follow on Twitter @@dotnetfdn">
 						<i class="fab fa-twitter"></i>
 					</a>
 				</div>


### PR DESCRIPTION
This fixes the side-scroll on most pages, yay!

Overall changes:
- Removes unused sections from _Layout
- Fixes a few `@` Razor issues that later .NET versions will go boom on.
- Fixes side scroll by tweaking classes used on the main content wrappers

Before:
![image](https://user-images.githubusercontent.com/454813/65365065-41887880-dbe4-11e9-9ecf-660a650da9bd.png)
After:
![image](https://user-images.githubusercontent.com/454813/65365074-549b4880-dbe4-11e9-8aa4-d24a13357751.png)
(same fix applies to all pages)

The membership website has another manual fix for this:
```css
body .row {
    margin-right: 0;
    margin-left: 0;
}
```
...but should be fixed the same way long-term.

If I missed the mark and we want these sections in the view still I'm happy to revert that piece, I just figured it was best to simplify why looking at this.