### PR TITLE
Fix search button style

### DIFF
--- a/src/wwwroot/css/style.css
+++ b/src/wwwroot/css/style.css
@@ -602,6 +602,11 @@ p.site-footer_textSection > a:visited {
     border-color: #e2068c;
 }
 
+#search .btn-primary svg.svg-inline--fa {
+	color: #fff;
+	vertical-align: 0;
+}
+
 .container-fluid {
     padding: 0;
 }


### PR DESCRIPTION
Changed the search button styling with a clearer icon color and beter vertical centering.

From this:
<img width="39" alt="Schermafbeelding 2019-10-09 om 15 32 50" src="https://user-images.githubusercontent.com/7275740/66486150-5735e300-eaaa-11e9-8282-e8dd04760134.png">

To this:
<img width="44" alt="Schermafbeelding 2019-10-09 om 15 33 11" src="https://user-images.githubusercontent.com/7275740/66486188-61f07800-eaaa-11e9-931a-b38f43a7e374.png">
