### PR TITLE
Fix link to Meetup on home page

### DIFF
--- a/src/Pages/Index.cshtml
+++ b/src/Pages/Index.cshtml
@@ -149,7 +149,7 @@
                 <h2>Upcoming Events and Meetups</h2>
                 <vc:meetup quantity="4" description-length="175" />
                 <p class="">
-                    <a class="link_title" href="/news">Find more events and Meetups ></a>
+                    <a class="link_title" href="https://meetup.com/pro/dotnet">Find more events and Meetups ></a>
                 </p>
             </div>
             <div class="page-section_column col-md-6 pad-fix--md">


### PR DESCRIPTION
The link when you click on 'Find more events and Meetups' on the home page currently navigates to the news page. This should probably link to the dotnet meetup page.

Fixes #53.