### PR TITLE
Same as #99, but leave in partial render calls

### DIFF
--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -98,14 +98,9 @@
 		</div>
 	</header>
 
-	@*<main id="site_wrapper">
-		<div id="site_container" class="">
-			@RenderBody()
-		</div>
-	</main>*@
 	<div id="site_wrapper" class="container-fluid cs-container flex-fill">
 
-		<div class="row">
+		<div class="row w-100">
 			<main id="site_container" role="main" class="col order-3">
 				@await Html.PartialAsync("AlertsPartial")
 				@RenderBody()


### PR DESCRIPTION
Looks like this project is based on cloudscribe, which defines AsidePrimaryVisible and other partials somewhere in the stack.

Example: https://github.com/cloudscribe/sample-idserver/blob/7388530cba8db08f5d6a1090fbfb7dab87d45963/OPServer/SharedThemes/sandstone/Shared/_Layout.cshtml#L12

I can't find where the source for that partial lives, presumably because the project is closed source...

@jongalloway @NickCraver 