### PR TITLE
Added menu link to blogs

### DIFF
--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -73,6 +73,9 @@
 							<a class="nav-link" href="/about">About</a>
 						</li>
 						<li class="main-menu_item nav-item">
+							<a class="nav-link" href="/blog">Blogs</a>
+						</li>
+						<li class="main-menu_item nav-item">
 							<a class="nav-link" href="/news">News</a>
 						</li>
 					</ul>


### PR DESCRIPTION
Site visitors might miss useful blog content from the foundation and ability to subscribe to blogs because blogs are not part of the main menu navigation that users are most likely to interact with. I feel the blog is a major page and it should be part of the main site menu navigation.