### PR TITLE
Page titles made dynamic. Some altered as they were duplicated

### DIFF
--- a/src/Pages/About.cshtml
+++ b/src/Pages/About.cshtml
@@ -3,7 +3,7 @@
 
 @{
 	Layout = "_Layout";
-	ViewData["Title"] = "About";
+	ViewData["Title"] = "About the .NET Foundation";
 	ViewData["BodyClass"] = "pages";
 }
 

--- a/src/Pages/Become-A-Member.cshtml
+++ b/src/Pages/Become-A-Member.cshtml
@@ -3,7 +3,7 @@
 
 @{
     Layout = "_Layout";
-    ViewData["Title"] = "Become a member";
+    ViewData["Title"] = "Become a Member of the .NET Foundation";
     ViewData["BodyClass"] = "pages";
 }
 

--- a/src/Pages/Code-Of-Conduct.cshtml
+++ b/src/Pages/Code-Of-Conduct.cshtml
@@ -3,7 +3,7 @@
 
 @{
     Layout = "_Layout";
-    ViewData["Title"] = "Code of Conduct";
+    ViewData["Title"] = ".NET Foundation Code of Conduct";
 }
 
 

--- a/src/Pages/FAQ.cshtml
+++ b/src/Pages/FAQ.cshtml
@@ -3,7 +3,7 @@
 
 @{
     Layout = "_Layout";
-    ViewData["Title"] = "FAQ";
+    ViewData["Title"] = ".NET Foundation FAQ";
 }
 
 

--- a/src/Pages/Get-Involved.cshtml
+++ b/src/Pages/Get-Involved.cshtml
@@ -3,7 +3,7 @@
 
 @{
     Layout = "_Layout";
-    ViewData["Title"] = "About";
+    ViewData["Title"] = "Get involved with the .NET Foundation";
     ViewData["BodyClass"] = "pages";
 }
 

--- a/src/Pages/News.cshtml
+++ b/src/Pages/News.cshtml
@@ -3,7 +3,7 @@
 
 @{
     Layout = "_Layout";
-    ViewData["Title"] = "About";
+    ViewData["Title"] = ".NET Foundation News";
     ViewData["BodyClass"] = "pages";
 }
 

--- a/src/Pages/Privacy-Policy.cshtml
+++ b/src/Pages/Privacy-Policy.cshtml
@@ -3,7 +3,7 @@
 
 @{
     Layout = "_Layout";
-    ViewData["Title"] = "Privacy Policy";
+    ViewData["Title"] = ".NET Foundation Privacy Policy";
 }
 
 <h2>Privacy Policy</h2>

--- a/src/Views/Projects/Index.cshtml
+++ b/src/Views/Projects/Index.cshtml
@@ -1,6 +1,6 @@
 ﻿@model dotnetfoundation.ViewModels.ProjectListViewModel
 @{
-	ViewData["Title"] = "Projects";
+	ViewData["Title"] = ".NET Foundation Projects";
 	ViewData["BodyClass"] = "pages";
 
 	string repoChecked = null;

--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -13,7 +13,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>.NET Foundation</title>
+    <title>@ViewData["Title"]</title>
     <link rel="apple-touch-icon" sizes="57x57" href="~/img/favicon/apple-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="60x60" href="~/img/favicon/apple-icon-60x60.png">
     <link rel="apple-touch-icon" sizes="72x72" href="~/img/favicon/apple-icon-72x72.png">


### PR DESCRIPTION
The title element on the _Layout shared view was static and always set to be .NET Foundation.
I've changed this to use the ViewData["Title"] data that is set in the Razor pages and therefore be dynamic.

I have also updated some of the page titles as they were duplicated. Feel free to change these to whatever you want them to be.